### PR TITLE
Fix out-of-range error in toString by slicing first.

### DIFF
--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -313,7 +313,7 @@ export default class Decoder {
   }
 
   private decodeString(offset: number, size: number) {
-    return this.db.toString('utf8', offset, offset + size);
+    return this.db.slice(offset, offset + size).toString();
   }
 
   private decodeBigUint(offset: number, size: number) {


### PR DESCRIPTION
Ever since the latest mmdb-lib (2.0.1) got included in the `maxmind` library via https://github.com/runk/node-maxmind/commit/9213a8ebab0270047635fbe9f32b4c060cc459fa, I've been getting out-of-range errors when trying to construct a reader on a really large mmdb file (~3GB). I boiled it down to this line and the following patch fixed it.

```
buffer.js:609
    slice: (buf, start, end) => buf.utf8Slice(start, end),
                                    ^

RangeError: Index out of range
    at Object.slice (buffer.js:609:37)
    at Uint8Array.toString (buffer.js:827:14)
    at Decoder.decodeString (/node_modules/mmdb-lib/lib/decoder.js:239:24)
    at Decoder.decodeByType (/node_modules/mmdb-lib/lib/decoder.js:82:36)
    at Decoder.decode (/node_modules/mmdb-lib/lib/decoder.js:58:21)
    at Decoder.decodeMap (/node_modules/mmdb-lib/lib/decoder.js:205:24)
    at Decoder.decodeByType (/node_modules/mmdb-lib/lib/decoder.js:84:29)
    at Decoder.decode (/node_modules/mmdb-lib/lib/decoder.js:58:21)
    at parseMetadata (/node_modules/mmdb-lib/lib/metadata.js:14:30)
    at Reader.load (/node_modules/mmdb-lib/lib/index.js:32:54) {
  code: 'ERR_OUT_OF_RANGE'
}
```