### PR TITLE
Add missing IP address traits

### DIFF
--- a/src/reader/response.ts
+++ b/src/reader/response.ts
@@ -70,12 +70,15 @@ interface TraitsRecord {
   readonly is_hosting_provider?: boolean;
   readonly is_legitimate_proxy?: boolean;
   readonly is_public_proxy?: boolean;
+  readonly is_residential_proxy?: boolean;
   readonly is_satellite_provider?: boolean;
   readonly is_tor_exit_node?: boolean;
   readonly isp?: string;
   readonly mobile_country_code?: string;
   readonly mobile_network_code?: string;
   readonly organization?: string;
+  readonly static_ip_score?: number;
+  readonly user_count?: number;
   readonly user_type?:
     | 'business'
     | 'cafe'


### PR DESCRIPTION
This adds `is_residential_proxy`, `static_ip_score` and `user_count` to response's ip address traits.

https://dev.maxmind.com/geoip/docs/web-services/responses?lang=en#schema--response--traits