### PR TITLE
feat: uint64 and uint128 now decode to BigInts

### DIFF
--- a/src/__test__/integration.test.ts
+++ b/src/__test__/integration.test.ts
@@ -90,10 +90,10 @@ describe('mmdb lib', () => {
             float: 0,
             int32: 0,
             map: {},
-            uint128: 0,
+            uint128: 0n,
             uint16: 0,
             uint32: 0,
-            uint64: 0,
+            uint64: 0n,
             utf8_string: '',
           },
         },
@@ -116,10 +116,10 @@ describe('section: data', () => {
       float: 1.100000023841858,
       int32: -268435456,
       map: { mapX: { arrayX: [7, 8, 9], utf8_stringX: 'hello' } },
-      uint128: '1329227995784915872903807060280344576',
+      uint128: 1329227995784915872903807060280344576n,
       uint16: 100,
       uint32: 268435456,
-      uint64: '1152921504606846976',
+      uint64: 1152921504606846976n,
       utf8_string: 'unicode! ☯ - ♫',
     });
   });
@@ -134,10 +134,10 @@ describe('section: data', () => {
       float: 0,
       int32: 0,
       map: {},
-      uint128: 0,
+      uint128: 0n,
       uint16: 0,
       uint32: 0,
-      uint64: 0,
+      uint64: 0n,
       utf8_string: '',
     });
   });
@@ -217,10 +217,10 @@ describe('getWithPrefixLength', () => {
         utf8_stringX: 'hello',
       },
     },
-    uint128: '1329227995784915872903807060280344576',
+    uint128: 1329227995784915872903807060280344576n,
     uint16: 0x64,
     uint32: 268435456,
-    uint64: '1152921504606846976',
+    uint64: 1152921504606846976n,
     utf8_string: 'unicode! ☯ - ♫',
   };
   const tests = [

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -42,7 +42,7 @@ export const parseMetadata = (db: Buffer): Metadata => {
   return {
     binaryFormatMajorVersion: metadata.binary_format_major_version,
     binaryFormatMinorVersion: metadata.binary_format_minor_version,
-    buildEpoch: new Date(metadata.build_epoch * 1000),
+    buildEpoch: new Date(Number(metadata.build_epoch) * 1000),
     databaseType: metadata.database_type,
     description: metadata.description,
     ipVersion: metadata.ip_version,


### PR DESCRIPTION
BREAKING CHANGE: Values stored in the database as a 64 bit or 128 bit
unsigned integer will now be decoded to a BigInt. Previously, they
would be decode to a number if they were less than 281,474,976,710,656
and a string otherwise.
