### PR TITLE
Handle Large MMDBs

### DIFF
--- a/src/decoder.test.ts
+++ b/src/decoder.test.ts
@@ -379,9 +379,11 @@ describe('lib/decoder', () => {
       return Buffer.concat([padding, header, contentBuf]);
     }
 
+    const MAX_INT_32 = 2147483648;
+
     it('should handle string just below 2^31 boundary', function () {
       this.timeout(15000);
-      const offset = 0x7ffffff0; // 2^31 - 16
+      const offset = MAX_INT_32 - 16;
       const content = 'boundary test';
 
       const buffer = createBufferWithStringAtOffset(offset, content);
@@ -398,7 +400,7 @@ describe('lib/decoder', () => {
 
     it('should handle when string at offset >= 2^31', function () {
       this.timeout(15000);
-      const offset = 0x80000000; // Exactly 2^31
+      const offset = MAX_INT_32;
       const content = 'test';
 
       const buffer = createBufferWithStringAtOffset(offset, content);

--- a/src/decoder.test.ts
+++ b/src/decoder.test.ts
@@ -352,6 +352,65 @@ describe('lib/decoder', () => {
         assert.deepStrictEqual(decoder.decode(0).value, tc.expected);
       });
     }
+
+    function createBufferWithStringAtOffset(
+      offset: number,
+      content: string
+    ): Buffer {
+      const contentBuf = Buffer.from(content);
+      const size = contentBuf.length;
+      const padding = Buffer.alloc(offset);
+
+      let header: Buffer;
+      if (size <= 0x1f) {
+        header = Buffer.from([0x40 | size]);
+      } else if (size <= 0xffff) {
+        header = Buffer.from([0x40 | 0x1f, (size >> 8) & 0xff, size & 0xff]);
+      } else {
+        header = Buffer.from([
+          0x5f,
+          (size >> 24) & 0xff,
+          (size >> 16) & 0xff,
+          (size >> 8) & 0xff,
+          size & 0xff,
+        ]);
+      }
+
+      return Buffer.concat([padding, header, contentBuf]);
+    }
+
+    it('should handle string just below 2^31 boundary', function () {
+      this.timeout(15000);
+      const offset = 0x7ffffff0; // 2^31 - 16
+      const content = 'boundary test';
+
+      const buffer = createBufferWithStringAtOffset(offset, content);
+
+      const decoder = new Decoder(buffer);
+
+      const result = decoder.decode(offset);
+      assert.strictEqual(result.value, content);
+      assert(
+        result.offset > offset,
+        `Offset ${result.offset} should be > ${offset}`
+      );
+    });
+
+    it('should handle when string at offset >= 2^31', function () {
+      this.timeout(15000);
+      const offset = 0x80000000; // Exactly 2^31
+      const content = 'test';
+
+      const buffer = createBufferWithStringAtOffset(offset, content);
+      const decoder = new Decoder(buffer);
+
+      const result = decoder.decode(offset);
+      assert.strictEqual(result.value, content);
+      assert(
+        result.offset > offset,
+        `Offset ${result.offset} should be > ${offset}`
+      );
+    });
   });
 
   describe('decodeUint() - uint16', () => {

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -281,9 +281,9 @@ export default class Decoder {
   }
 
   private decodeString(offset: number, size: number) {
-    const newOffset = offset + size 
-    return newOffset >= 2147483648 // 2^31 Nodejs Buffer limit
-      ? this.db.slice(offset, newOffset).toString('utf8')
+    const newOffset = offset + size;
+    return newOffset >= 2147483648 // 2^31 Buffer.toString() limit
+      ? this.db.subarray(offset, newOffset).toString('utf8')
       : this.db.toString('utf8', offset, newOffset);
   }
 

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -6,6 +6,8 @@ utils.assert(
   'Apparently you are using old version of node. Please upgrade to node 10.4.x or above.'
 );
 
+const MAX_INT_32 = 2_147_483_647;
+
 enum DataType {
   Extended = 0,
   Pointer = 1,
@@ -282,7 +284,7 @@ export default class Decoder {
 
   private decodeString(offset: number, size: number) {
     const newOffset = offset + size;
-    return newOffset >= 2147483648 // 2^31 Buffer.toString() limit
+    return newOffset >= MAX_INT_32
       ? this.db.subarray(offset, newOffset).toString('utf8')
       : this.db.toString('utf8', offset, newOffset);
   }

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -281,7 +281,10 @@ export default class Decoder {
   }
 
   private decodeString(offset: number, size: number) {
-    return this.db.toString('utf8', offset, offset + size);
+    const newOffset = offset + size 
+    return newOffset >= 2147483648 // 2^31 Nodejs Buffer limit
+      ? this.db.slice(offset, newOffset).toString('utf8')
+      : this.db.toString('utf8', offset, newOffset);
   }
 
   private decodeBigUint(offset: number, size: number): bigint {


### PR DESCRIPTION
I am unable to read large MMDBs (> ~2.1GB), which I think is due to NodeJs `Buffer` not being able to handle sizes above 2^31 - 1 bytes (~2.1 GB). 

This re-introduces an earlier fix (https://github.com/runk/mmdb-lib/pull/13/commits/f843ecd1881ea7380a0a2ed6a5c4c8c6bca526f0), slicing before calling `toString`.
At the same time, it makes sure to not apply the fix to small files to retain performance improvement by https://github.com/runk/mmdb-lib/pull/225/commits/dbab38f603a4f2e1cbdd56a95b6559b8e22caf72

```bash
RangeError: Index out of range
    at Object.slice (node:buffer:638:37)
    at Uint8Array.toString (node:buffer:857:14)
    at Decoder.decodeString (/app/node_modules/mmdb-lib/lib/decoder.js:237:24)
    at Decoder.decodeByType (/app/node_modules/mmdb-lib/lib/decoder.js:82:36)
    at Decoder.decode (/app/node_modules/mmdb-lib/lib/decoder.js:58:21)
    at Decoder.decodeMap (/app/node_modules/mmdb-lib/lib/decoder.js:204:24)
    at Decoder.decodeByType (/app/node_modules/mmdb-lib/lib/decoder.js:84:29)
    at Decoder.decode (/app/node_modules/mmdb-lib/lib/decoder.js:58:21)
    at parseMetadata (/app/node_modules/mmdb-lib/lib/metadata.js:13:30)
    at Reader.load (/app/node_modules/mmdb-lib/lib/index.js:36:54)
    at new Reader (/app/node_modules/mmdb-lib/lib/index.js:29:14)
```

**Testing**

Verified with:
-  MMDB files (<1GB)
-  Large MMDB files (~2.4GB): Now load successfully